### PR TITLE
Fix vertical vias

### DIFF
--- a/abs_templates_ec/analog_mos/planar.py
+++ b/abs_templates_ec/analog_mos/planar.py
@@ -1446,9 +1446,6 @@ class MOSTechPlanarGeneric(MOSTech):
             raise ValueError('Differential connection not supported yet.')
 
         layout_info = mos_info['layout_info']
-        print('mos_info')
-        print(mos_info)
-
         sd_yc = mos_info['sd_yc']
 
         lch_unit = layout_info['lch_unit']
@@ -1512,8 +1509,6 @@ class MOSTechPlanarGeneric(MOSTech):
         # draw drain/source vias
         num_s = (seg + 2) // 2
         num_d = seg + 1 - num_s
-        print('dylist')
-        print(d_y_list)
         mx_yb, mx_yt = d_y_list[-1][0] - sd_yc, d_y_list[-1][1] - sd_yc
         od_yb, od_yt = d_y_list[0][0] - sd_yc, d_y_list[0][1] - sd_yc
 
@@ -1832,9 +1827,6 @@ class MOSTechPlanarGeneric(MOSTech):
         lay_name_table = self.config['layer_name']
 
         mos_constants = self.get_mos_tech_constants(lch_unit)
-        print(mos_constants)
-        print('foo')
-        print(drc_info)
         sub_m1_enc_le = mos_constants['sub_m1_enc_le']
         md_w = mos_constants['md_w']
 
@@ -1854,9 +1846,6 @@ class MOSTechPlanarGeneric(MOSTech):
         if mbot_yt is None:
             mbot_yt = mx_yt
 
-        print('mbots')
-        print(mbot_yb)
-        print(mbot_yt)
         for bot_lay_id in range(start_layer, top_layer):
             via_benc_le = bot_enc_le_info[bot_lay_id]
             via_tenc_le = top_enc_le_info[bot_lay_id]
@@ -1939,7 +1928,7 @@ class MOSTechPlanarGeneric(MOSTech):
             return False
         if arr_nmax is not None and num_via > arr_nmax:
             via_sp = arr_sp
-            num_via = (area_h + via_sp) // (via_w + via_sp)
+            num_via = (area_h + via_sp) // (via_h + via_sp)
 
         #Array height calculated using heigth of the via
         via_harr = num_via * (via_h + via_sp) - via_sp #This is the minimum area enclosures should be added

--- a/abs_templates_ec/analog_mos/planar.py
+++ b/abs_templates_ec/analog_mos/planar.py
@@ -1446,6 +1446,9 @@ class MOSTechPlanarGeneric(MOSTech):
             raise ValueError('Differential connection not supported yet.')
 
         layout_info = mos_info['layout_info']
+        print('mos_info')
+        print(mos_info)
+
         sd_yc = mos_info['sd_yc']
 
         lch_unit = layout_info['lch_unit']
@@ -1509,8 +1512,11 @@ class MOSTechPlanarGeneric(MOSTech):
         # draw drain/source vias
         num_s = (seg + 2) // 2
         num_d = seg + 1 - num_s
+        print('dylist')
+        print(d_y_list)
         mx_yb, mx_yt = d_y_list[-1][0] - sd_yc, d_y_list[-1][1] - sd_yc
         od_yb, od_yt = d_y_list[0][0] - sd_yc, d_y_list[0][1] - sd_yc
+
         drc_info = self.get_conn_drc_info(lch_unit, 'd')
         self._draw_vertical_vias(
             template,
@@ -1826,6 +1832,9 @@ class MOSTechPlanarGeneric(MOSTech):
         lay_name_table = self.config['layer_name']
 
         mos_constants = self.get_mos_tech_constants(lch_unit)
+        print(mos_constants)
+        print('foo')
+        print(drc_info)
         sub_m1_enc_le = mos_constants['sub_m1_enc_le']
         md_w = mos_constants['md_w']
 
@@ -1845,6 +1854,9 @@ class MOSTechPlanarGeneric(MOSTech):
         if mbot_yt is None:
             mbot_yt = mx_yt
 
+        print('mbots')
+        print(mbot_yb)
+        print(mbot_yt)
         for bot_lay_id in range(start_layer, top_layer):
             via_benc_le = bot_enc_le_info[bot_lay_id]
             via_tenc_le = top_enc_le_info[bot_lay_id]
@@ -1919,7 +1931,8 @@ class MOSTechPlanarGeneric(MOSTech):
         yt_min = min(mbot_yt - via_benc_le, mtop_yt - via_tenc_le)
         via_yc = (yb_max + yt_min) // 2
         area_h = yt_min - yb_max
-        num_via = (area_h + via_sp) // (via_w + via_sp)
+        #Number of vias calculated using heigth of the via
+        num_via = (area_h + via_sp) // (via_h + via_sp)
         if num_via < 0:
             import pdb
             pdb.set_trace()
@@ -1928,7 +1941,8 @@ class MOSTechPlanarGeneric(MOSTech):
             via_sp = arr_sp
             num_via = (area_h + via_sp) // (via_w + via_sp)
 
-        via_harr = num_via * (via_w + via_sp) - via_sp
+        #Array height calculated using heigth of the via
+        via_harr = num_via * (via_h + via_sp) - via_sp #This is the minimum area enclosures should be added
         via_yb = via_yc - via_harr // 2
         via_yt = via_yb + via_harr
 

--- a/abs_templates_ec/analog_mos/planar.py
+++ b/abs_templates_ec/analog_mos/planar.py
@@ -1915,7 +1915,7 @@ class MOSTechPlanarGeneric(MOSTech):
         via_yc = (yb_max + yt_min) // 2
         area_h = yt_min - yb_max
         num_via = (area_h + via_sp) // (via_w + via_sp)
-        if num_via <= 0:
+        if num_via < 0:
             import pdb
             pdb.set_trace()
             return False


### PR DESCRIPTION
Hi @ayan-biswas . Additional fix for via shape calculation in MOSTechPlanarGeneric. I think the algorithm incorrectly used width instead of height. 

This change should probably be done for  finfet as well.