### PR TITLE
Fix guard ring generation

### DIFF
--- a/abs_templates_ec/analog_mos/planar.py
+++ b/abs_templates_ec/analog_mos/planar.py
@@ -1915,7 +1915,7 @@ class MOSTechPlanarGeneric(MOSTech):
         via_yc = (yb_max + yt_min) // 2
         area_h = yt_min - yb_max
         num_via = (area_h + via_sp) // (via_w + via_sp)
-        if num_via <= 0:
+        if num_via < 0:
             import pdb
             pdb.set_trace()
             return False


### PR DESCRIPTION
@ayan-biswas
As requested, this points now to new_fix

num_via = 0 should not cause error

I think num_via = 0 should not cause error at the modified place of the code. Without modification guard ring generation fails, although with the modification the ring seems legit.

DISCLAIMER: I am a BAG newbie, so please thest the suggestion with some design known to work properly. If original form is correct, let me know. I then need to dig deeper to figure out what's wrong in my design/process setup.

Thanks,
Marko